### PR TITLE
Replace short keyid by fingerprint when getting public key

### DIFF
--- a/source/dev/dev_guide.rst
+++ b/source/dev/dev_guide.rst
@@ -191,7 +191,7 @@ Run these commands to add the Kurento repository to your system configuration:
 .. code-block:: shell
 
    # Import the Kurento repository signing key
-   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83
+   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 234821A61B67740F89BFD669FC8A16625AFA7A83
 
    # Get Ubuntu version definitions
    source /etc/lsb-release

--- a/source/project/relnotes/v6_10_0.rst
+++ b/source/project/relnotes/v6_10_0.rst
@@ -19,7 +19,7 @@ To install KMS on this version of Ubuntu, just follow the usual :doc:`installati
 
    DISTRO="bionic"  # KMS for Ubuntu 18.04 (Bionic)
 
-   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83
+   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 234821A61B67740F89BFD669FC8A16625AFA7A83
 
    sudo tee "/etc/apt/sources.list.d/kurento.list" >/dev/null <<EOF
    # Kurento Media Server - Release packages

--- a/source/user/installation.rst
+++ b/source/user/installation.rst
@@ -172,7 +172,7 @@ Open a terminal and run these commands:
    .. code-block:: shell
 
       # Import the Kurento repository signing key
-      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83
+      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 234821A61B67740F89BFD669FC8A16625AFA7A83
 
       # Get Ubuntu version definitions
       source /etc/lsb-release

--- a/source/user/installation_dev.rst
+++ b/source/user/installation_dev.rst
@@ -51,7 +51,7 @@ Open a terminal and run these commands:
    .. code-block:: shell
 
       # Import the Kurento repository signing key
-      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83
+      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 234821A61B67740F89BFD669FC8A16625AFA7A83
 
       # Get Ubuntu version definitions
       source /etc/lsb-release


### PR DESCRIPTION
## What is the current behavior you want to change?
The documentation suggests to use the short key ID 5AFA7A83 as a
identifier for the public key used for the APT repository. As several
keys with same short key ID can be produced and have been produced in
the past (see article
https://threatpost.com/of-gpg-collisions-and-ux-security/109713/ from
2014 for example),  this a security problem.



## What is the new behavior provided by this change?
This commit replaces the short key IDs by the key's fingerprint.

## How has this been tested?
I ran the following test on Debian GNU/Linux 10 and 11 (pre-release), Ubuntu 16.04 and 18.04:

```
# apt-key del FC8A16625AFA7A83
OK
# sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 234821A61B67740F89BFD669FC8A16625AFA7A83
Executing: /tmp/apt-key-gpghome.oEb5M1mf3X/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys 234821A61B67740F89BFD669FC8A16625AFA7A83
gpg: key FC8A16625AFA7A83: public key "Openvidu - Kurento TEAM <openvidu@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository


## Checklist
- [x] I have read the Contribution Guidelines
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
